### PR TITLE
Add simple homepage and refine UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,27 @@
-# Image Converter & Editor
+# Image Tools
 
-A free and open-source web-based tool for converting, resizing, and compressing images. This project is built as a Progressive Web App (PWA) with features like dark mode and drag & drop support.
+A free and open-source collection of browser based utilities for working with images. The app runs entirely on the client so your files never leave your device. It also functions offline as a PWA.
 
 ## Features
 
-- **Image Conversion:** Convert between PNG, JPEG, and WebP formats.
-- **Image Resizing:** Adjust width and height while preserving aspect ratio.
-- **Compression:** Set quality for JPEG/WebP images using a slider.
-- **PWA Integration:** Installable and works offline.
-- **Dark Mode:** Toggle between light and dark themes.
-- **Live Preview & Drag & Drop Upload:** Instant preview and user-friendly image upload.
+- **Format Converter:** Change images between PNG, JPEG and WebP.
+- **Image Resizer:** Specify new dimensions for any picture.
+- **Compressor:** Reduce JPEG file size with a quality slider.
+- **Cropper:** Trim images to the area you need.
+- **Rotator:** Rotate images by 90° increments.
+- **Dark/Light Theme:** Toggle between themes.
+- **Offline Ready:** Works without a network connection.
+
+## Pages
+
+- **Home (`index.html`)** – introduction and links to the tools.
+- **Format Converter (`converter.html`)** – convert between image formats.
+- **Resizer (`resize.html`)** – change dimensions of your image.
+- **Compressor (`compress.html`)** – shrink JPEGs using a quality slider.
+- **Cropper (`crop.html`)** – crop to a specific region.
+- **Rotator (`rotate.html`)** – rotate images in steps.
 
 ## Demo
 
-View the live demo here:  
+View the live demo here:
 [Live Demo](https://dhanushrs1.github.io/Image-Converter-/)
-

--- a/compress.html
+++ b/compress.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Image Compressor</title>
+  <link rel="manifest" href="manifest.json">
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --primary: #bb86fc;
+      --primary-dark: #985eff;
+      --bg-dark: #121212;
+      --bg-light: #ffffff;
+    }
+    body {
+      font-family: 'Roboto', sans-serif;
+      background: var(--bg-dark);
+      color: #e0e0e0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      transition: background 0.3s, color 0.3s;
+    }
+    body.light {
+      background: var(--bg-light);
+      color: #333;
+    }
+    header, footer {
+      background: #1e1e1e;
+      padding: 1rem 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    header.light, footer.light { background: #f0f0f0; }
+    nav a {
+      margin-left: 1rem;
+      text-decoration: none;
+      color: inherit;
+      font-weight: 500;
+    }
+    nav a.active { color: var(--primary); }
+    .toggle-switch { display: flex; align-items: center; cursor: pointer; }
+    .toggle-switch input { display: none; }
+    .slider {
+      width: 40px; height: 20px; background: #555; border-radius: 20px; margin-left: 0.5rem;
+      position: relative; transition: background 0.3s;
+    }
+    .slider:before {
+      content: ""; position: absolute; width: 16px; height: 16px; border-radius: 50%; background: #fff;
+      top: 2px; left: 2px; transition: transform 0.3s;
+    }
+    input:checked + .slider { background: var(--primary); }
+    input:checked + .slider:before { transform: translateX(20px); }
+    main { flex: 1; display: flex; justify-content: center; align-items: center; padding: 2rem; }
+    .container { background: #1e1e1e; padding: 2rem; border-radius: 10px; width: 100%; max-width: 500px; box-shadow: 0 0 10px rgba(0,0,0,0.5); }
+    .container.light { background: #fff; }
+    .container h2 { text-align: center; margin-bottom: 1rem; }
+    .input-group { margin-bottom: 1rem; }
+    input, select, button { width: 100%; padding: 0.5rem; border-radius: 5px; border: 1px solid #444; background: transparent; color: inherit; }
+    input:focus, select:focus, button:focus { outline: none; border-color: var(--primary); }
+    button { background: var(--primary); border: none; color: #fff; cursor: pointer; transition: background 0.3s; }
+    button:hover { background: var(--primary-dark); }
+    #downloadLink { display: none; margin-top: 1rem; text-align: center; text-decoration: none; background: var(--primary); color: #fff; padding: 0.5rem; border-radius: 5px; }
+    #previewContainer { text-align: center; margin-bottom: 1rem; }
+    #previewContainer img { max-width: 100%; border-radius: 5px; }
+  </style>
+</head>
+<body class="dark">
+  <header id="header">
+    <h1>Image Tools</h1>
+    <nav class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="converter.html">Convert</a>
+      <a href="resize.html">Resize</a>
+      <a href="compress.html">Compress</a>
+      <a href="crop.html">Crop</a>
+      <a href="rotate.html">Rotate</a>
+    </nav>
+    <div class="toggle-switch">
+      <span>Light Mode</span>
+      <input type="checkbox" id="darkModeToggle" checked>
+      <label for="darkModeToggle" class="slider"></label>
+    </div>
+  </header>
+  <main>
+    <div class="container" id="container">
+      <div class="input-group"><input type="file" id="imageInput" accept="image/*"></div>
+      <div id="previewContainer"></div>
+      <div class="input-group"><label>Quality: <span id="qualityValue">0.8</span></label><input type="range" id="qualityInput" min="0.1" max="1" step="0.05" value="0.8"></div>
+      <button id="compressButton">Compress</button>
+      <canvas id="canvas" style="display:none;"></canvas>
+      <a id="downloadLink"></a>
+    </div>
+  </main>
+  <footer id="footer">
+    <p>© 2025 Dhanush R S || All rights reserved.</p>
+  </footer>
+  <script>
+    const darkModeToggle = document.getElementById('darkModeToggle');
+    const body = document.body;
+    const header = document.getElementById('header');
+    const container = document.getElementById('container');
+    const footer = document.getElementById('footer');
+    const applyTheme = () => {
+      const light = !darkModeToggle.checked;
+      body.classList.toggle('light', light);
+      header.classList.toggle('light', light);
+      container.classList.toggle('light', light);
+      footer.classList.toggle('light', light);
+    };
+    darkModeToggle.addEventListener('change', applyTheme);
+    applyTheme();
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => navigator.serviceWorker.register('service-worker.js'));
+    }
+  </script>
+  <script>
+const imageInput = document.getElementById('imageInput');
+const qualityInput = document.getElementById('qualityInput');
+const qualityValue = document.getElementById('qualityValue');
+const compressButton = document.getElementById('compressButton');
+const canvas = document.getElementById('canvas');
+const downloadLink = document.getElementById('downloadLink');
+const preview = document.getElementById('previewContainer');
+let img = new Image();
+imageInput.addEventListener('change', e => {
+  const file = e.target.files[0];
+  if(file){
+    const reader = new FileReader();
+    reader.onload = ev => {
+      img.src = ev.target.result;
+      preview.innerHTML = `<img src="${ev.target.result}" alt="preview">`;
+    };
+    reader.readAsDataURL(file);
+  }
+});
+qualityInput.addEventListener('input', () => { qualityValue.textContent = qualityInput.value; });
+compressButton.addEventListener('click', () => {
+  if(!img.src){ alert('Please choose an image'); return; }
+  if(!img.complete){ img.onload = perform; } else { perform(); }
+});
+function perform(){
+  canvas.width = img.width;
+  canvas.height = img.height;
+  canvas.getContext('2d').drawImage(img,0,0);
+  const q = parseFloat(qualityInput.value);
+  const data = canvas.toDataURL('image/jpeg', q);
+  downloadLink.href = data;
+  downloadLink.download = 'compressed.jpg';
+  downloadLink.textContent = 'Download JPEG';
+  downloadLink.style.display = 'block';
+}
+  </script>
+</body>
+</html>

--- a/converter.html
+++ b/converter.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Image Converter</title>
+  <link rel="manifest" href="manifest.json">
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --primary: #bb86fc;
+      --primary-dark: #985eff;
+      --bg-dark: #121212;
+      --bg-light: #ffffff;
+    }
+    body {
+      font-family: 'Roboto', sans-serif;
+      background: var(--bg-dark);
+      color: #e0e0e0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      transition: background 0.3s, color 0.3s;
+    }
+    body.light {
+      background: var(--bg-light);
+      color: #333;
+    }
+    header, footer {
+      background: #1e1e1e;
+      padding: 1rem 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    header.light, footer.light { background: #f0f0f0; }
+    nav a {
+      margin-left: 1rem;
+      text-decoration: none;
+      color: inherit;
+      font-weight: 500;
+    }
+    nav a.active { color: var(--primary); }
+    .toggle-switch { display: flex; align-items: center; cursor: pointer; }
+    .toggle-switch input { display: none; }
+    .slider {
+      width: 40px; height: 20px; background: #555; border-radius: 20px; margin-left: 0.5rem;
+      position: relative; transition: background 0.3s;
+    }
+    .slider:before {
+      content: ""; position: absolute; width: 16px; height: 16px; border-radius: 50%; background: #fff;
+      top: 2px; left: 2px; transition: transform 0.3s;
+    }
+    input:checked + .slider { background: var(--primary); }
+    input:checked + .slider:before { transform: translateX(20px); }
+    main { flex: 1; display: flex; justify-content: center; align-items: center; padding: 2rem; }
+    .container { background: #1e1e1e; padding: 2rem; border-radius: 10px; width: 100%; max-width: 500px; box-shadow: 0 0 10px rgba(0,0,0,0.5); }
+    .container.light { background: #fff; }
+    .container h2 { text-align: center; margin-bottom: 1rem; }
+    .input-group { margin-bottom: 1rem; }
+    input, select, button { width: 100%; padding: 0.5rem; border-radius: 5px; border: 1px solid #444; background: transparent; color: inherit; }
+    input:focus, select:focus, button:focus { outline: none; border-color: var(--primary); }
+    button { background: var(--primary); border: none; color: #fff; cursor: pointer; transition: background 0.3s; }
+    button:hover { background: var(--primary-dark); }
+    #downloadLink { display: none; margin-top: 1rem; text-align: center; text-decoration: none; background: var(--primary); color: #fff; padding: 0.5rem; border-radius: 5px; }
+    #previewContainer { text-align: center; margin-bottom: 1rem; }
+    #previewContainer img { max-width: 100%; border-radius: 5px; }
+  </style>
+</head>
+<body class="dark">
+  <header id="header">
+    <h1>Image Tools</h1>
+    <nav class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="converter.html">Convert</a>
+      <a href="resize.html">Resize</a>
+      <a href="compress.html">Compress</a>
+      <a href="crop.html">Crop</a>
+      <a href="rotate.html">Rotate</a>
+    </nav>
+    <div class="toggle-switch">
+      <span>Light Mode</span>
+      <input type="checkbox" id="darkModeToggle" checked>
+      <label for="darkModeToggle" class="slider"></label>
+    </div>
+  </header>
+  <main>
+    <div class="container" id="container">
+      <div class="input-group"><input type="file" id="imageInput" accept="image/*"></div>
+      <div id="previewContainer"></div>
+      <div class="input-group"><select id="formatSelect"><option value="image/png">PNG</option><option value="image/jpeg">JPEG</option><option value="image/webp">WebP</option></select></div>
+      <button id="convertButton">Convert</button>
+      <canvas id="canvas" style="display:none;"></canvas>
+      <a id="downloadLink"></a>
+    </div>
+  </main>
+  <footer id="footer">
+    <p>© 2025 Dhanush R S || All rights reserved.</p>
+  </footer>
+  <script>
+    const darkModeToggle = document.getElementById('darkModeToggle');
+    const body = document.body;
+    const header = document.getElementById('header');
+    const container = document.getElementById('container');
+    const footer = document.getElementById('footer');
+    const applyTheme = () => {
+      const light = !darkModeToggle.checked;
+      body.classList.toggle('light', light);
+      header.classList.toggle('light', light);
+      container.classList.toggle('light', light);
+      footer.classList.toggle('light', light);
+    };
+    darkModeToggle.addEventListener('change', applyTheme);
+    applyTheme();
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => navigator.serviceWorker.register('service-worker.js'));
+    }
+  </script>
+  <script>
+const imageInput = document.getElementById('imageInput');
+const formatSelect = document.getElementById('formatSelect');
+const convertButton = document.getElementById('convertButton');
+const canvas = document.getElementById('canvas');
+const downloadLink = document.getElementById('downloadLink');
+const preview = document.getElementById('previewContainer');
+let img = new Image();
+imageInput.addEventListener('change', e => {
+  const file = e.target.files[0];
+  if(file){
+    const reader = new FileReader();
+    reader.onload = ev => {
+      img.src = ev.target.result;
+      preview.innerHTML = `<img src="${ev.target.result}" alt="preview">`;
+    };
+    reader.readAsDataURL(file);
+  }
+});
+convertButton.addEventListener('click', () => {
+  if(!img.src){ alert('Please choose an image'); return; }
+  if(!img.complete){ img.onload = perform; } else { perform(); }
+});
+function perform(){
+  canvas.width = img.width;
+  canvas.height = img.height;
+  canvas.getContext('2d').drawImage(img,0,0);
+  const format = formatSelect.value;
+  const data = canvas.toDataURL(format);
+  const ext = format.split('/')[1].replace('jpeg','jpg');
+  downloadLink.href = data;
+  downloadLink.download = `converted.${ext}`;
+  downloadLink.textContent = `Download ${ext.toUpperCase()}`;
+  downloadLink.style.display = 'block';
+}
+  </script>
+</body>
+</html>

--- a/crop.html
+++ b/crop.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Image Cropper</title>
+  <link rel="manifest" href="manifest.json">
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --primary: #bb86fc;
+      --primary-dark: #985eff;
+      --bg-dark: #121212;
+      --bg-light: #ffffff;
+    }
+    body {
+      font-family: 'Roboto', sans-serif;
+      background: var(--bg-dark);
+      color: #e0e0e0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      transition: background 0.3s, color 0.3s;
+    }
+    body.light {
+      background: var(--bg-light);
+      color: #333;
+    }
+    header, footer {
+      background: #1e1e1e;
+      padding: 1rem 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    header.light, footer.light { background: #f0f0f0; }
+    nav a {
+      margin-left: 1rem;
+      text-decoration: none;
+      color: inherit;
+      font-weight: 500;
+    }
+    nav a.active { color: var(--primary); }
+    .toggle-switch { display: flex; align-items: center; cursor: pointer; }
+    .toggle-switch input { display: none; }
+    .slider {
+      width: 40px; height: 20px; background: #555; border-radius: 20px; margin-left: 0.5rem;
+      position: relative; transition: background 0.3s;
+    }
+    .slider:before {
+      content: ""; position: absolute; width: 16px; height: 16px; border-radius: 50%; background: #fff;
+      top: 2px; left: 2px; transition: transform 0.3s;
+    }
+    input:checked + .slider { background: var(--primary); }
+    input:checked + .slider:before { transform: translateX(20px); }
+    main { flex: 1; display: flex; justify-content: center; align-items: center; padding: 2rem; }
+    .container { background: #1e1e1e; padding: 2rem; border-radius: 10px; width: 100%; max-width: 500px; box-shadow: 0 0 10px rgba(0,0,0,0.5); }
+    .container.light { background: #fff; }
+    .container h2 { text-align: center; margin-bottom: 1rem; }
+    .input-group { margin-bottom: 1rem; }
+    input, select, button { width: 100%; padding: 0.5rem; border-radius: 5px; border: 1px solid #444; background: transparent; color: inherit; }
+    input:focus, select:focus, button:focus { outline: none; border-color: var(--primary); }
+    button { background: var(--primary); border: none; color: #fff; cursor: pointer; transition: background 0.3s; }
+    button:hover { background: var(--primary-dark); }
+    #downloadLink { display: none; margin-top: 1rem; text-align: center; text-decoration: none; background: var(--primary); color: #fff; padding: 0.5rem; border-radius: 5px; }
+    #previewContainer { text-align: center; margin-bottom: 1rem; }
+    #previewContainer img { max-width: 100%; border-radius: 5px; }
+  </style>
+</head>
+<body class="dark">
+  <header id="header">
+    <h1>Image Tools</h1>
+    <nav class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="converter.html">Convert</a>
+      <a href="resize.html">Resize</a>
+      <a href="compress.html">Compress</a>
+      <a href="crop.html">Crop</a>
+      <a href="rotate.html">Rotate</a>
+    </nav>
+    <div class="toggle-switch">
+      <span>Light Mode</span>
+      <input type="checkbox" id="darkModeToggle" checked>
+      <label for="darkModeToggle" class="slider"></label>
+    </div>
+  </header>
+  <main>
+    <div class="container" id="container">
+      <div class="input-group"><input type="file" id="imageInput" accept="image/*"></div>
+      <div id="previewContainer"></div>
+      <div class="input-group"><input type="number" id="xInput" placeholder="X"></div>
+      <div class="input-group"><input type="number" id="yInput" placeholder="Y"></div>
+      <div class="input-group"><input type="number" id="wInput" placeholder="Width"></div>
+      <div class="input-group"><input type="number" id="hInput" placeholder="Height"></div>
+      <button id="cropButton">Crop</button>
+      <canvas id="canvas" style="display:none;"></canvas>
+      <a id="downloadLink"></a>
+    </div>
+  </main>
+  <footer id="footer">
+    <p>© 2025 Dhanush R S || All rights reserved.</p>
+  </footer>
+  <script>
+    const darkModeToggle = document.getElementById('darkModeToggle');
+    const body = document.body;
+    const header = document.getElementById('header');
+    const container = document.getElementById('container');
+    const footer = document.getElementById('footer');
+    const applyTheme = () => {
+      const light = !darkModeToggle.checked;
+      body.classList.toggle('light', light);
+      header.classList.toggle('light', light);
+      container.classList.toggle('light', light);
+      footer.classList.toggle('light', light);
+    };
+    darkModeToggle.addEventListener('change', applyTheme);
+    applyTheme();
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => navigator.serviceWorker.register('service-worker.js'));
+    }
+  </script>
+  <script>
+const imageInput = document.getElementById('imageInput');
+const xInput = document.getElementById('xInput');
+const yInput = document.getElementById('yInput');
+const wInput = document.getElementById('wInput');
+const hInput = document.getElementById('hInput');
+const cropButton = document.getElementById('cropButton');
+const canvas = document.getElementById('canvas');
+const downloadLink = document.getElementById('downloadLink');
+const preview = document.getElementById('previewContainer');
+let img = new Image();
+imageInput.addEventListener('change', e => {
+  const file = e.target.files[0];
+  if(file){
+    const reader = new FileReader();
+    reader.onload = ev => {
+      img.src = ev.target.result;
+      preview.innerHTML = `<img src="${ev.target.result}" alt="preview">`;
+    };
+    reader.readAsDataURL(file);
+  }
+});
+cropButton.addEventListener('click', () => {
+  if(!img.src){ alert('Please choose an image'); return; }
+  if(!img.complete){ img.onload = perform; } else { perform(); }
+});
+function perform(){
+  const x = parseInt(xInput.value) || 0;
+  const y = parseInt(yInput.value) || 0;
+  const w = parseInt(wInput.value) || img.width;
+  const h = parseInt(hInput.value) || img.height;
+  canvas.width = w;
+  canvas.height = h;
+  canvas.getContext('2d').drawImage(img, x, y, w, h, 0, 0, w, h);
+  const data = canvas.toDataURL('image/png');
+  downloadLink.href = data;
+  downloadLink.download = 'cropped.png';
+  downloadLink.textContent = 'Download PNG';
+  downloadLink.style.display = 'block';
+}
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,390 +3,109 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Image Converter & Editor</title>
-  <!-- Google Fonts -->
+  <title>Image Tools</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet" />
-  <!-- PWA Manifest -->
   <link rel="manifest" href="manifest.json">
   <style>
-    /* Reset & Global Styles */
     * { margin: 0; padding: 0; box-sizing: border-box; }
-    body { 
-      font-family: 'Roboto', sans-serif; 
-      background: #f0f2f5; 
-      min-height: 100vh; 
-      display: flex; 
-      flex-direction: column; 
-      transition: background 0.3s, color 0.3s; 
+    :root {
+      --primary: #bb86fc;
+      --primary-dark: #985eff;
+      --bg-dark: #121212;
+      --bg-light: #ffffff;
     }
-    body.dark { background: #121212; color: #e0e0e0; }
-    /* Header */
-    header { 
-      background: #fff; 
-      padding: 1rem 2rem; 
-      box-shadow: 0 2px 4px rgba(0,0,0,0.1); 
-      display: flex; 
-      justify-content: space-between; 
-      align-items: center; 
+    body {
+      font-family: 'Roboto', sans-serif;
+      background: var(--bg-dark);
+      color: #e0e0e0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      transition: background 0.3s, color 0.3s;
     }
-    header.dark { background: #1e1e1e; }
-    header h1 { font-size: 1.8rem; color: #667eea; }
-    /* Dark Mode Toggle Switch */
+    body.light { background: var(--bg-light); color: #333; }
+    header, footer {
+      background: #1e1e1e;
+      padding: 1rem 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    header.light, footer.light { background: #f0f0f0; }
+    nav a { margin-left: 1rem; text-decoration: none; color: inherit; font-weight: 500; }
+    nav a.active { color: var(--primary); }
     .toggle-switch { display: flex; align-items: center; cursor: pointer; }
     .toggle-switch input { display: none; }
-    .slider { 
-      width: 40px; 
-      height: 20px; 
-      background: #ccc; 
-      border-radius: 20px; 
-      position: relative; 
-      transition: background 0.3s; 
-      margin-left: 0.5rem; 
-    }
-    .slider:before { 
-      content: ""; 
-      position: absolute; 
-      width: 16px; 
-      height: 16px; 
-      border-radius: 50%; 
-      background: #fff; 
-      top: 2px; 
-      left: 2px; 
-      transition: transform 0.3s; 
-    }
-    input:checked + .slider { background: #667eea; }
+    .slider { width: 40px; height: 20px; background: #555; border-radius: 20px; position: relative; margin-left: 0.5rem; transition: background 0.3s; }
+    .slider:before { content:""; position:absolute; width:16px; height:16px; background:#fff; top:2px; left:2px; border-radius:50%; transition:transform 0.3s; }
+    input:checked + .slider { background: var(--primary); }
     input:checked + .slider:before { transform: translateX(20px); }
-    /* Main */
-    main { 
-      flex: 1; 
-      display: flex; 
-      justify-content: center; 
-      align-items: center; 
-      padding: 1rem; 
-    }
-    .container { 
-      background: #fff; 
-      border-radius: 10px; 
-      box-shadow: 0 10px 25px rgba(0,0,0,0.1); 
-      width: 100%; 
-      max-width: 700px; 
-      padding: 2rem; 
-      transition: background 0.3s, color 0.3s; 
-    }
-    .container.dark { background: #1e1e1e; color: #e0e0e0; }
-    .container h2 { text-align: center; margin-bottom: 1rem; }
-    .container p { text-align: center; margin-bottom: 1.5rem; }
-    .input-group { margin-bottom: 1rem; }
-    .input-group label { display: block; margin-bottom: 0.5rem; font-weight: 500; }
-    /* Dropzone Styling */
-    .dropzone { 
-      border: 2px dashed #ccc; 
-      border-radius: 5px; 
-      padding: 2rem; 
-      text-align: center; 
-      color: #888; 
-      cursor: pointer; 
-      transition: background 0.3s, border-color 0.3s, color 0.3s; 
-      margin-bottom: 1rem; 
-    }
-    .dropzone:hover { background: #f9f9f9; }
-    .dropzone.dragover { background: #f0f0f0; border-color: #667eea; color: #333; }
-    input[type="file"] { display: none; }
-    /* Styled Select, Button & Inputs */
-    select, button, input[type="number"], input[type="range"] { 
-      width: 100%; 
-      padding: 0.75rem; 
-      border-radius: 5px; 
-      border: 1px solid #ccc; 
-      font-size: 1rem; 
-      transition: border-color 0.3s; 
-    }
-    select:focus, button:focus, input:focus { outline: none; border-color: #667eea; }
-    button { 
-      background: #667eea; 
-      color: #fff; 
-      border: none; 
-      cursor: pointer; 
-      margin-top: 1rem; 
-      transition: background 0.3s; 
-    }
-    button:hover { background: #556cd6; }
-    .resize-inputs { display: flex; gap: 1rem; }
-    .resize-inputs input { flex: 1; }
-    /* Download Link */
-    #downloadLink { 
-      display: block; 
-      text-align: center; 
-      margin-top: 1.5rem; 
-      text-decoration: none; 
-      color: #fff; 
-      background: #38a169; 
-      padding: 0.75rem; 
-      border-radius: 5px; 
-      transition: background 0.3s; 
-    }
-    #downloadLink:hover { background: #2f855a; }
-    /* Footer */
-    footer { 
-      background: #fff; 
-      text-align: center; 
-      padding: 1rem 2rem; 
-      box-shadow: 0 -2px 4px rgba(0,0,0,0.1); 
-    }
-    footer.dark { background: #1e1e1e; }
-    footer p { color: #555; }
-    /* Image Preview */
-    #previewContainer { text-align: center; margin-bottom: 1rem; }
-    #previewContainer img { max-width: 100%; border-radius: 5px; }
-    /* Toast Notification */
-    #toast {
-      position: fixed;
-      bottom: 20px;
-      right: 20px;
-      background: #667eea;
-      color: #fff;
-      padding: 1rem 1.5rem;
-      border-radius: 5px;
-      opacity: 0;
-      visibility: hidden;
-      transition: opacity 0.3s;
-      z-index: 1000;
-    }
-    #toast.show {
-      opacity: 1;
-      visibility: visible;
-    }
-    @media (max-width: 480px) {
-      .container { padding: 1.5rem; }
-      .resize-inputs { flex-direction: column; }
-    }
+    main { flex:1; padding:2rem; text-align:center; }
+    .hero { margin-bottom:2rem; }
+    .hero h2 { font-size:2rem; margin-bottom:0.5rem; }
+    .cta { display:inline-block; background:var(--primary); color:#fff; padding:0.75rem 1.5rem; border-radius:5px; text-decoration:none; transition:background 0.3s; margin-top:1rem; }
+    .cta:hover { background:var(--primary-dark); }
+    .cards { display:flex; flex-wrap:wrap; gap:1rem; justify-content:center; margin-top:1rem; }
+    .card { background:#1e1e1e; padding:1rem; border-radius:8px; width:160px; text-decoration:none; color:inherit; box-shadow:0 2px 6px rgba(0,0,0,0.4); transition:transform 0.2s; }
+    .card:hover { transform:translateY(-4px); }
+    .card h4 { margin-bottom:0.5rem; }
+    .light .card { background:#fff; box-shadow:0 2px 6px rgba(0,0,0,0.1); }
   </style>
 </head>
-<body>
-  <!-- Header with Dark Mode Toggle -->
+<body class="dark">
   <header id="header">
-    <h1>Image Converter & Editor</h1>
+    <h1>Image Tools</h1>
+    <nav class="nav-links">
+      <a href="index.html" class="active">Home</a>
+      <a href="converter.html">Convert</a>
+      <a href="resize.html">Resize</a>
+      <a href="compress.html">Compress</a>
+      <a href="crop.html">Crop</a>
+      <a href="rotate.html">Rotate</a>
+    </nav>
     <div class="toggle-switch">
-      <span>Dark Mode</span>
-      <input type="checkbox" id="darkModeToggle">
+      <span>Light Mode</span>
+      <input type="checkbox" id="darkModeToggle" checked>
       <label for="darkModeToggle" class="slider"></label>
     </div>
   </header>
-
-  <!-- Main Content -->
   <main>
-    <div class="container" id="container">
-      <h2>Convert, Resize & Compress Your Images</h2>
-      <p>Upload an image, choose your options below, and click convert!</p>
-
-      <!-- File Selection with Drag & Drop -->
-      <div class="input-group">
-        <label for="imageInput" class="dropzone" id="dropzone">Click or Drag & Drop Image Here</label>
-        <input type="file" id="imageInput" accept="image/*">
+    <section class="hero">
+      <h2>Powerful image tools in your browser</h2>
+      <p>No uploads required. Everything runs locally.</p>
+      <a href="converter.html" class="cta">Start Converting</a>
+    </section>
+    <section class="tools">
+      <h3>Tools</h3>
+      <div class="cards">
+        <a class="card" href="converter.html"><h4>Format Converter</h4><p>Change file types quickly.</p></a>
+        <a class="card" href="resize.html"><h4>Image Resizer</h4><p>Adjust width and height.</p></a>
+        <a class="card" href="compress.html"><h4>Compressor</h4><p>Reduce JPEG size.</p></a>
+        <a class="card" href="crop.html"><h4>Cropper</h4><p>Crop unwanted areas.</p></a>
+        <a class="card" href="rotate.html"><h4>Rotator</h4><p>Rotate by 90° steps.</p></a>
       </div>
-
-      <!-- Image Preview -->
-      <div id="previewContainer"></div>
-
-      <!-- Format Selector -->
-      <div class="input-group">
-        <label for="formatSelect">Output Format:</label>
-        <select id="formatSelect">
-          <option value="image/png">PNG</option>
-          <option value="image/jpeg">JPEG</option>
-          <option value="image/webp">WebP</option>
-        </select>
-      </div>
-
-      <!-- Resize Options -->
-      <div class="input-group">
-        <label>Resize Image (optional):</label>
-        <div class="resize-inputs">
-          <input type="number" id="widthInput" placeholder="Width (px)" min="1">
-          <input type="number" id="heightInput" placeholder="Height (px)" min="1">
-        </div>
-      </div>
-
-      <!-- Quality Slider for Compression -->
-      <div class="input-group">
-        <label for="qualityInput">
-          Quality (for JPEG/WebP): <span id="qualityValue">0.92</span>
-        </label>
-        <input type="range" id="qualityInput" min="0.1" max="1" step="0.01" value="0.92">
-      </div>
-
-      <!-- Convert Button -->
-      <button id="convertButton">Convert Image</button>
-
-      <!-- Hidden Canvas for Conversion -->
-      <canvas id="canvas" style="display: none;"></canvas>
-
-      <!-- Download Link -->
-      <a id="downloadLink" download="converted_image" href="#" style="display: none;">Download Converted Image</a>
-    </div>
+    </section>
   </main>
-
-  <!-- Toast Notification -->
-  <div id="toast">Conversion Complete!</div>
-
-  <!-- Footer -->
   <footer id="footer">
     <p>© 2025 Dhanush R S || All rights reserved.</p>
   </footer>
-
   <script>
-    /* ===== Dark Mode Toggle ===== */
     const darkModeToggle = document.getElementById('darkModeToggle');
     const body = document.body;
     const header = document.getElementById('header');
-    const container = document.getElementById('container');
     const footer = document.getElementById('footer');
-
-    darkModeToggle.addEventListener('change', () => {
-      if(darkModeToggle.checked){
-        body.classList.add('dark');
-        header.classList.add('dark');
-        container.classList.add('dark');
-        footer.classList.add('dark');
-      } else {
-        body.classList.remove('dark');
-        header.classList.remove('dark');
-        container.classList.remove('dark');
-        footer.classList.remove('dark');
-      }
-    });
-
-    /* ===== PWA Service Worker Registration ===== */
+    const applyTheme = () => {
+      const light = !darkModeToggle.checked;
+      body.classList.toggle('light', light);
+      header.classList.toggle('light', light);
+      footer.classList.toggle('light', light);
+    };
+    darkModeToggle.addEventListener('change', applyTheme);
+    applyTheme();
     if ('serviceWorker' in navigator) {
-      window.addEventListener('load', function() {
-        navigator.serviceWorker.register('service-worker.js')
-          .then(registration => {
-            console.log('Service Worker registered with scope:', registration.scope);
-          })
-          .catch(err => {
-            console.log('Service Worker registration failed:', err);
-          });
-      });
-    }
-
-    /* ===== Toast Notification Function ===== */
-    function showToast(message) {
-      const toast = document.getElementById('toast');
-      toast.textContent = message;
-      toast.classList.add('show');
-      setTimeout(() => {
-        toast.classList.remove('show');
-      }, 3000);
-    }
-
-    /* ===== Image Processing ===== */
-    const imageInput = document.getElementById('imageInput');
-    const dropzone = document.getElementById('dropzone');
-    const convertButton = document.getElementById('convertButton');
-    const formatSelect = document.getElementById('formatSelect');
-    const widthInput = document.getElementById('widthInput');
-    const heightInput = document.getElementById('heightInput');
-    const qualityInput = document.getElementById('qualityInput');
-    const qualityValue = document.getElementById('qualityValue');
-    const canvas = document.getElementById('canvas');
-    const downloadLink = document.getElementById('downloadLink');
-    const previewContainer = document.getElementById('previewContainer');
-
-    let img = new Image();
-
-    // Drag & Drop Handlers
-    dropzone.addEventListener('dragover', (e) => {
-      e.preventDefault();
-      dropzone.classList.add('dragover');
-    });
-    dropzone.addEventListener('dragleave', (e) => {
-      e.preventDefault();
-      dropzone.classList.remove('dragover');
-    });
-    dropzone.addEventListener('drop', (e) => {
-      e.preventDefault();
-      dropzone.classList.remove('dragover');
-      const file = e.dataTransfer.files[0];
-      if(file) {
-        // Update the hidden file input with the dropped file so the
-        // selected file can be reused by other handlers. FileList is
-        // read-only, so create a new DataTransfer object.
-        const dt = new DataTransfer();
-        dt.items.add(file);
-        imageInput.files = dt.files;
-        loadImage(file);
-      }
-    });
-    // Open file dialog on click
-    dropzone.addEventListener('click', () => {
-      imageInput.click();
-    });
-    imageInput.addEventListener('change', function(e) {
-      const file = e.target.files[0];
-      if(file) {
-        loadImage(file);
-      }
-    });
-    function loadImage(file) {
-      const reader = new FileReader();
-      reader.onload = function(event) {
-        img.src = event.target.result;
-        // Show live preview
-        previewContainer.innerHTML = '<img src="' + event.target.result + '" alt="Image Preview">';
-      };
-      reader.readAsDataURL(file);
-    }
-
-    // Update quality slider display
-    qualityInput.addEventListener('input', function() {
-      qualityValue.textContent = qualityInput.value;
-    });
-
-    // Conversion & Processing
-    convertButton.addEventListener('click', function() {
-      if(!img.src) {
-        alert('Please select an image first!');
-        return;
-      }
-      if(!img.complete) {
-        img.onload = performConversion;
-      } else {
-        performConversion();
-      }
-    });
-    function performConversion() {
-      // Determine target dimensions
-      let targetWidth = parseInt(widthInput.value) || img.width;
-      let targetHeight = parseInt(heightInput.value) || img.height;
-      if(widthInput.value && !heightInput.value) {
-        targetHeight = Math.round((targetWidth / img.width) * img.height);
-      }
-      if(heightInput.value && !widthInput.value) {
-        targetWidth = Math.round((targetHeight / img.height) * img.width);
-      }
-      canvas.width = targetWidth;
-      canvas.height = targetHeight;
-      const ctx = canvas.getContext('2d');
-      ctx.clearRect(0,0,canvas.width, canvas.height);
-      ctx.drawImage(img, 0, 0, targetWidth, targetHeight);
-      const outputFormat = formatSelect.value;
-      const quality = parseFloat(qualityInput.value);
-      let dataURL;
-      if(outputFormat === 'image/jpeg' || outputFormat === 'image/webp') {
-        dataURL = canvas.toDataURL(outputFormat, quality);
-      } else {
-        dataURL = canvas.toDataURL(outputFormat);
-      }
-      let extension = 'png';
-      if(outputFormat === 'image/jpeg') extension = 'jpg';
-      else if(outputFormat === 'image/webp') extension = 'webp';
-      downloadLink.href = dataURL;
-      downloadLink.download = `converted_image.${extension}`;
-      downloadLink.textContent = `Download Converted Image (${extension.toUpperCase()})`;
-      downloadLink.style.display = 'block';
-      showToast('Conversion Complete!');
+      window.addEventListener('load', () => navigator.serviceWorker.register('service-worker.js'));
     }
   </script>
 </body>

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-    "name": "Image Converter & Editor",
-    "short_name": "ImgConverter",
+    "name": "Image Tools",
+    "short_name": "ImgTools",
     "start_url": ".",
     "display": "standalone",
-    "background_color": "#f0f2f5",
-    "theme_color": "#667eea",
+    "background_color": "#121212",
+    "theme_color": "#bb86fc",
     "icons": [
       {
         "src": "icon-192.png",

--- a/resize.html
+++ b/resize.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Image Resizer</title>
+  <link rel="manifest" href="manifest.json">
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --primary: #bb86fc;
+      --primary-dark: #985eff;
+      --bg-dark: #121212;
+      --bg-light: #ffffff;
+    }
+    body {
+      font-family: 'Roboto', sans-serif;
+      background: var(--bg-dark);
+      color: #e0e0e0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      transition: background 0.3s, color 0.3s;
+    }
+    body.light {
+      background: var(--bg-light);
+      color: #333;
+    }
+    header, footer {
+      background: #1e1e1e;
+      padding: 1rem 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    header.light, footer.light { background: #f0f0f0; }
+    nav a {
+      margin-left: 1rem;
+      text-decoration: none;
+      color: inherit;
+      font-weight: 500;
+    }
+    nav a.active { color: var(--primary); }
+    .toggle-switch { display: flex; align-items: center; cursor: pointer; }
+    .toggle-switch input { display: none; }
+    .slider {
+      width: 40px; height: 20px; background: #555; border-radius: 20px; margin-left: 0.5rem;
+      position: relative; transition: background 0.3s;
+    }
+    .slider:before {
+      content: ""; position: absolute; width: 16px; height: 16px; border-radius: 50%; background: #fff;
+      top: 2px; left: 2px; transition: transform 0.3s;
+    }
+    input:checked + .slider { background: var(--primary); }
+    input:checked + .slider:before { transform: translateX(20px); }
+    main { flex: 1; display: flex; justify-content: center; align-items: center; padding: 2rem; }
+    .container { background: #1e1e1e; padding: 2rem; border-radius: 10px; width: 100%; max-width: 500px; box-shadow: 0 0 10px rgba(0,0,0,0.5); }
+    .container.light { background: #fff; }
+    .container h2 { text-align: center; margin-bottom: 1rem; }
+    .input-group { margin-bottom: 1rem; }
+    input, select, button { width: 100%; padding: 0.5rem; border-radius: 5px; border: 1px solid #444; background: transparent; color: inherit; }
+    input:focus, select:focus, button:focus { outline: none; border-color: var(--primary); }
+    button { background: var(--primary); border: none; color: #fff; cursor: pointer; transition: background 0.3s; }
+    button:hover { background: var(--primary-dark); }
+    #downloadLink { display: none; margin-top: 1rem; text-align: center; text-decoration: none; background: var(--primary); color: #fff; padding: 0.5rem; border-radius: 5px; }
+    #previewContainer { text-align: center; margin-bottom: 1rem; }
+    #previewContainer img { max-width: 100%; border-radius: 5px; }
+  </style>
+</head>
+<body class="dark">
+  <header id="header">
+    <h1>Image Tools</h1>
+    <nav class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="converter.html">Convert</a>
+      <a href="resize.html">Resize</a>
+      <a href="compress.html">Compress</a>
+      <a href="crop.html">Crop</a>
+      <a href="rotate.html">Rotate</a>
+    </nav>
+    <div class="toggle-switch">
+      <span>Light Mode</span>
+      <input type="checkbox" id="darkModeToggle" checked>
+      <label for="darkModeToggle" class="slider"></label>
+    </div>
+  </header>
+  <main>
+    <div class="container" id="container">
+      <div class="input-group"><input type="file" id="imageInput" accept="image/*"></div>
+      <div id="previewContainer"></div>
+      <div class="input-group"><input type="number" id="widthInput" placeholder="Width"></div>
+      <div class="input-group"><input type="number" id="heightInput" placeholder="Height"></div>
+      <button id="resizeButton">Resize</button>
+      <canvas id="canvas" style="display:none;"></canvas>
+      <a id="downloadLink"></a>
+    </div>
+  </main>
+  <footer id="footer">
+    <p>© 2025 Dhanush R S || All rights reserved.</p>
+  </footer>
+  <script>
+    const darkModeToggle = document.getElementById('darkModeToggle');
+    const body = document.body;
+    const header = document.getElementById('header');
+    const container = document.getElementById('container');
+    const footer = document.getElementById('footer');
+    const applyTheme = () => {
+      const light = !darkModeToggle.checked;
+      body.classList.toggle('light', light);
+      header.classList.toggle('light', light);
+      container.classList.toggle('light', light);
+      footer.classList.toggle('light', light);
+    };
+    darkModeToggle.addEventListener('change', applyTheme);
+    applyTheme();
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => navigator.serviceWorker.register('service-worker.js'));
+    }
+  </script>
+  <script>
+const imageInput = document.getElementById('imageInput');
+const widthInput = document.getElementById('widthInput');
+const heightInput = document.getElementById('heightInput');
+const resizeButton = document.getElementById('resizeButton');
+const canvas = document.getElementById('canvas');
+const downloadLink = document.getElementById('downloadLink');
+const preview = document.getElementById('previewContainer');
+let img = new Image();
+imageInput.addEventListener('change', e => {
+  const file = e.target.files[0];
+  if(file){
+    const reader = new FileReader();
+    reader.onload = ev => {
+      img.src = ev.target.result;
+      preview.innerHTML = `<img src="${ev.target.result}" alt="preview">`;
+    };
+    reader.readAsDataURL(file);
+  }
+});
+resizeButton.addEventListener('click', () => {
+  if(!img.src){ alert('Please choose an image'); return; }
+  if(!img.complete){ img.onload = perform; } else { perform(); }
+});
+function perform(){
+  const w = parseInt(widthInput.value) || img.width;
+  const h = parseInt(heightInput.value) || img.height;
+  canvas.width = w;
+  canvas.height = h;
+  canvas.getContext('2d').drawImage(img,0,0,w,h);
+  const data = canvas.toDataURL('image/png');
+  downloadLink.href = data;
+  downloadLink.download = 'resized.png';
+  downloadLink.textContent = 'Download PNG';
+  downloadLink.style.display = 'block';
+}
+  </script>
+</body>
+</html>

--- a/rotate.html
+++ b/rotate.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Image Rotator</title>
+  <link rel="manifest" href="manifest.json">
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --primary: #bb86fc;
+      --primary-dark: #985eff;
+      --bg-dark: #121212;
+      --bg-light: #ffffff;
+    }
+    body {
+      font-family: 'Roboto', sans-serif;
+      background: var(--bg-dark);
+      color: #e0e0e0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      transition: background 0.3s, color 0.3s;
+    }
+    body.light {
+      background: var(--bg-light);
+      color: #333;
+    }
+    header, footer {
+      background: #1e1e1e;
+      padding: 1rem 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    header.light, footer.light { background: #f0f0f0; }
+    nav a {
+      margin-left: 1rem;
+      text-decoration: none;
+      color: inherit;
+      font-weight: 500;
+    }
+    nav a.active { color: var(--primary); }
+    .toggle-switch { display: flex; align-items: center; cursor: pointer; }
+    .toggle-switch input { display: none; }
+    .slider {
+      width: 40px; height: 20px; background: #555; border-radius: 20px; margin-left: 0.5rem;
+      position: relative; transition: background 0.3s;
+    }
+    .slider:before {
+      content: ""; position: absolute; width: 16px; height: 16px; border-radius: 50%; background: #fff;
+      top: 2px; left: 2px; transition: transform 0.3s;
+    }
+    input:checked + .slider { background: var(--primary); }
+    input:checked + .slider:before { transform: translateX(20px); }
+    main { flex: 1; display: flex; justify-content: center; align-items: center; padding: 2rem; }
+    .container { background: #1e1e1e; padding: 2rem; border-radius: 10px; width: 100%; max-width: 500px; box-shadow: 0 0 10px rgba(0,0,0,0.5); }
+    .container.light { background: #fff; }
+    .container h2 { text-align: center; margin-bottom: 1rem; }
+    .input-group { margin-bottom: 1rem; }
+    input, select, button { width: 100%; padding: 0.5rem; border-radius: 5px; border: 1px solid #444; background: transparent; color: inherit; }
+    input:focus, select:focus, button:focus { outline: none; border-color: var(--primary); }
+    button { background: var(--primary); border: none; color: #fff; cursor: pointer; transition: background 0.3s; }
+    button:hover { background: var(--primary-dark); }
+    #downloadLink { display: none; margin-top: 1rem; text-align: center; text-decoration: none; background: var(--primary); color: #fff; padding: 0.5rem; border-radius: 5px; }
+    #previewContainer { text-align: center; margin-bottom: 1rem; }
+    #previewContainer img { max-width: 100%; border-radius: 5px; }
+  </style>
+</head>
+<body class="dark">
+  <header id="header">
+    <h1>Image Tools</h1>
+    <nav class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="converter.html">Convert</a>
+      <a href="resize.html">Resize</a>
+      <a href="compress.html">Compress</a>
+      <a href="crop.html">Crop</a>
+      <a href="rotate.html">Rotate</a>
+    </nav>
+    <div class="toggle-switch">
+      <span>Light Mode</span>
+      <input type="checkbox" id="darkModeToggle" checked>
+      <label for="darkModeToggle" class="slider"></label>
+    </div>
+  </header>
+  <main>
+    <div class="container" id="container">
+      <div class="input-group"><input type="file" id="imageInput" accept="image/*"></div>
+      <div id="previewContainer"></div>
+      <div class="input-group"><select id="angleSelect"><option value="90">90°</option><option value="180">180°</option><option value="270">270°</option></select></div>
+      <button id="rotateButton">Rotate</button>
+      <canvas id="canvas" style="display:none;"></canvas>
+      <a id="downloadLink"></a>
+    </div>
+  </main>
+  <footer id="footer">
+    <p>© 2025 Dhanush R S || All rights reserved.</p>
+  </footer>
+  <script>
+    const darkModeToggle = document.getElementById('darkModeToggle');
+    const body = document.body;
+    const header = document.getElementById('header');
+    const container = document.getElementById('container');
+    const footer = document.getElementById('footer');
+    const applyTheme = () => {
+      const light = !darkModeToggle.checked;
+      body.classList.toggle('light', light);
+      header.classList.toggle('light', light);
+      container.classList.toggle('light', light);
+      footer.classList.toggle('light', light);
+    };
+    darkModeToggle.addEventListener('change', applyTheme);
+    applyTheme();
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => navigator.serviceWorker.register('service-worker.js'));
+    }
+  </script>
+  <script>
+const imageInput = document.getElementById('imageInput');
+const angleSelect = document.getElementById('angleSelect');
+const rotateButton = document.getElementById('rotateButton');
+const canvas = document.getElementById('canvas');
+const downloadLink = document.getElementById('downloadLink');
+const preview = document.getElementById('previewContainer');
+let img = new Image();
+imageInput.addEventListener('change', e => {
+  const file = e.target.files[0];
+  if(file){
+    const reader = new FileReader();
+    reader.onload = ev => {
+      img.src = ev.target.result;
+      preview.innerHTML = `<img src="${ev.target.result}" alt="preview">`;
+    };
+    reader.readAsDataURL(file);
+  }
+});
+rotateButton.addEventListener('click', () => {
+  if(!img.src){ alert('Please choose an image'); return; }
+  if(!img.complete){ img.onload = perform; } else { perform(); }
+});
+function perform(){
+  const angle = parseInt(angleSelect.value);
+  const radians = angle * Math.PI / 180;
+  const width = angle % 180 === 0 ? img.width : img.height;
+  const height = angle % 180 === 0 ? img.height : img.width;
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  ctx.translate(canvas.width/2, canvas.height/2);
+  ctx.rotate(radians);
+  ctx.drawImage(img, -img.width/2, -img.height/2);
+  const data = canvas.toDataURL('image/png');
+  downloadLink.href = data;
+  downloadLink.download = 'rotated.png';
+  downloadLink.textContent = 'Download PNG';
+  downloadLink.style.display = 'block';
+}
+  </script>
+</body>
+</html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,25 +1,21 @@
-const CACHE_NAME = 'img-converter-cache-v1';
+const CACHE_NAME = 'img-tools-cache-v1';
 const urlsToCache = [
   './',
   './index.html',
-  './manifest.json',
-  // List any additional assets (CSS, JS, images, etc.)
+  './converter.html',
+  './resize.html',
+  './compress.html',
+  './crop.html',
+  './rotate.html',
+  './manifest.json'
 ];
-
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open(CACHE_NAME)
-      .then(cache => {
-        return cache.addAll(urlsToCache);
-      })
+    caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
   );
 });
-
 self.addEventListener('fetch', event => {
   event.respondWith(
-    caches.match(event.request)
-      .then(response => {
-        return response || fetch(event.request);
-      })
+    caches.match(event.request).then(resp => resp || fetch(event.request))
   );
 });


### PR DESCRIPTION
## Summary
- redesign the project README
- add a dedicated homepage
- move existing converter app to `convert.html`
- update styles and navigation
- adjust PWA settings for the new page

## Testing
- `npm test` *(fails: `package.json` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685c1cdc423c83279173472142427d61